### PR TITLE
Fix: recordId.trim is not a function when passed from sub-workflow

### DIFF
--- a/MEMORY/WORK/20260322-000000_auto-fix-review-findings-smartsuite-pr/PRD.md
+++ b/MEMORY/WORK/20260322-000000_auto-fix-review-findings-smartsuite-pr/PRD.md
@@ -1,0 +1,36 @@
+---
+task: Auto-fix code review findings on SmartSuite PR
+slug: 20260322-000000_auto-fix-review-findings-smartsuite-pr
+effort: standard
+phase: complete
+progress: 7/8
+mode: interactive
+started: 2026-03-22T00:00:00Z
+updated: 2026-03-22T00:00:00Z
+---
+
+## Context
+
+PR #6 fixes the "recordId.trim is not a function" runtime error by replacing unsafe `as string` casts with `asIdString()` helper across three operation files. The review verdict was APPROVE with a single LOW-severity finding (import order).
+
+### Risks
+- Import ordering change could create inconsistency across files (reviewer explicitly flagged this)
+
+## Criteria
+
+- [ ] ISC-1: PR number and branch identified from artifact
+- [ ] ISC-2: On correct PR head branch (archon/thread-4db4692e)
+- [ ] ISC-3: All review artifacts read and findings extracted
+- [ ] ISC-4: Every finding triaged FIX or SKIP with documented reason
+- [ ] ISC-5: All FIX findings applied (or marked BLOCKED)
+- [ ] ISC-6: Type check passes after changes
+- [ ] ISC-7: Fix report artifact written to correct path
+- [ ] ISC-8: GitHub comment posted on PR #6
+
+## Decisions
+
+Finding 1 (import order, LOW) — SKIP. Reviewer recommended Option A (leave as-is). The `updateRecord.operation.ts` file already uses `debugLog`-first ordering; alphabetizing two files while leaving a third unchanged would create more inconsistency. No functional impact.
+
+No FIX findings remain. No commit/push needed.
+
+## Verification

--- a/MEMORY/WORK/20260322-120000_review-pr-scope-recordid-trim-fix/PRD.md
+++ b/MEMORY/WORK/20260322-120000_review-pr-scope-recordid-trim-fix/PRD.md
@@ -1,0 +1,61 @@
+---
+task: Review PR scope for recordId trim fix
+slug: 20260322-120000_review-pr-scope-recordid-trim-fix
+effort: extended
+phase: complete
+progress: 23/23
+mode: interactive
+started: 2026-03-22T12:00:00Z
+updated: 2026-03-22T12:02:00Z
+---
+
+## Context
+
+PR Review Scope workflow for fix of GitHub issue #5: 'recordId.trim is not a function'. Root cause in getRecord.operation.ts:19, deleteRecord.operation.ts:35, and updateRecord.operation.ts:19 where recordId cast as string fails when null/undefined at runtime. Fix uses String(this.getNodeParameter(...) ?? '').
+
+This is a pre-review scope step that gathers all context, runs pre-review checks, finds workflow artifacts, creates directory structure, and writes a scope manifest for parallel review agents.
+
+### Risks
+- PR may be already merged (commit 7d4bb09 says "(#5)" suggesting PR #5 is closed) — need to handle gracefully
+- Merge conflicts would block the entire workflow
+- CI may be failing, requiring a warning
+- Workflow artifacts may not exist (manual PR) — scope should proceed anyway
+- Branch may be significantly behind base
+- gh CLI auth issues could fail all checks
+- Artifacts directory at specified path may not exist (mkdir -p handles this)
+
+## Criteria
+
+- [x] ISC-1: PR number identified from branch, artifacts file, or argument parsing
+- [x] ISC-2: PR state is OPEN (not merged or closed)
+- [x] ISC-3: PR title extracted from gh pr view
+- [x] ISC-4: PR head and base branch names extracted
+- [x] ISC-5: PR author and URL extracted
+- [x] ISC-6: Merge conflict status checked via gh pr view mergeable field
+- [x] ISC-7: Workflow halts with clear message if conflicts detected
+- [x] ISC-8: CI check status retrieved showing pass/fail/pending counts
+- [x] ISC-9: Commits-behind-base count calculated via git rev-list
+- [x] ISC-10: Draft status determined from PR metadata
+- [x] ISC-11: Changed file count determined from PR metadata
+- [x] ISC-12: Additions and deletions counts determined
+- [x] ISC-13: Full PR diff retrieved via gh pr diff
+- [x] ISC-14: Changed files listed and categorized by type (source/test/docs/config)
+- [x] ISC-15: CLAUDE.md rules read and noted for reviewers
+- [x] ISC-16: Artifacts runs directory checked for investigation.md
+- [x] ISC-17: Artifacts runs directory checked for plan-context.md
+- [x] ISC-18: Scope limits extracted from workflow artifact if found
+- [x] ISC-19: Implementation deviations noted if implementation.md found
+- [x] ISC-20: Review artifacts directory created at specified path
+- [x] ISC-21: Stale review artifacts older than 7 days cleaned
+- [x] ISC-22: scope.md written with pre-review status table
+- [x] ISC-23: scope.md contains file categories, workflow context, CI details
+
+## Decisions
+
+## Verification
+
+All 23 criteria verified via direct tool output:
+- PR #6: OPEN, MERGEABLE/CLEAN, 0 commits behind main, isDraft=false, 3 files +5/-5
+- CI: no checks configured (noted)
+- Workflow artifacts: investigation.md (OUT OF SCOPE extracted) + implementation.md (deviation documented)
+- scope.md written: 123 lines, 14 sections at artifacts/runs/d8d5ed38c07b2db05724ced66d0d13df/review/scope.md

--- a/src/nodes/SmartSuite/actions/record/deleteRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/deleteRecord.operation.ts
@@ -2,7 +2,7 @@
 
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { debugLog } from '../../helpers/utils';
+import { debugLog, asIdString } from '../../helpers/utils';
 import { apiRequest } from '../../transport/smartSuiteApi';
 import { getTableId } from '../../helpers/validation';
 import { tableInput } from '../../shared/resourceInputs';
@@ -32,7 +32,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
   const returnData: INodeExecutionData[] = [];
 
   for (let i = 0; i < items.length; i++) {
-    const recordId = this.getNodeParameter('recordId', i) as string;
+    const recordId = asIdString(this.getNodeParameter('recordId', i));
     if (!recordId.trim()) {
       throw new NodeOperationError(
         this.getNode(),

--- a/src/nodes/SmartSuite/actions/record/getRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/getRecord.operation.ts
@@ -1,7 +1,7 @@
 // src/nodes/SmartSuite/actions/record/getRecord.operation.ts
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { debugLog } from '../../helpers/utils';
+import { debugLog, asIdString } from '../../helpers/utils';
 import { apiRequest } from '../../transport/smartSuiteApi';
 import { getSolutionId, getTableId } from '../../helpers/validation';
 
@@ -16,7 +16,7 @@ export async function execute(
   const returnData: INodeExecutionData[] = [];
 
   for (let i = 0; i < items.length; i++) {
-    const recordId = this.getNodeParameter('recordId', i) as string;
+    const recordId = asIdString(this.getNodeParameter('recordId', i));
     if (!recordId.trim()) {
       throw new NodeOperationError(
         this.getNode(),

--- a/src/nodes/SmartSuite/actions/record/updateRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/updateRecord.operation.ts
@@ -16,7 +16,7 @@ export async function execute(
   const returnData: INodeExecutionData[] = [];
 
   for (let i = 0; i < items.length; i++) {
-    const recordId = this.getNodeParameter('recordId', i) as string;
+    const recordId = asIdString(this.getNodeParameter('recordId', i));
     if (!recordId.trim()) {
       throw new NodeOperationError(
         this.getNode(),


### PR DESCRIPTION
## Summary

Fixes a runtime crash when `recordId` is passed from a sub-workflow as `null` or `undefined`. The previous `as string` cast silently accepted non-string values, causing `.trim()` to throw `recordId.trim is not a function`. The fix uses an `asIdString()` helper that safely coerces the value to a string before trimming.

## Changes

- `src/nodes/SmartSuite/actions/record/getRecord.operation.ts` — use `asIdString()` instead of `as string` cast for recordId
- `src/nodes/SmartSuite/actions/record/deleteRecord.operation.ts` — use `asIdString()` instead of `as string` cast for recordId
- `src/nodes/SmartSuite/actions/record/updateRecord.operation.ts` — use `asIdString()` instead of `as string` cast for recordId

## Validation

- [x] Fix applied consistently across all three affected operation files
- [x] `asIdString()` helper imported in deleteRecord and getRecord (was already available in updateRecord context)
- [x] Existing `.trim()` validation check preserved — produces clear error on empty/null recordId
- [x] TypeScript cast safety: no unsafe `as string` assertion on external input

## Testing Notes

Reproducer: pass a recordId from a sub-workflow expression that resolves to `null` at runtime. Before fix: `TypeError: recordId.trim is not a function`. After fix: `NodeOperationError: Record ID is required`.

---

Closes #5
