### PR TITLE
Fix: support multi-value array input for LinkedRecord and similar fields

### DIFF
--- a/src/nodes/SmartSuite/__tests__/actions/record/createRecord.test.ts
+++ b/src/nodes/SmartSuite/__tests__/actions/record/createRecord.test.ts
@@ -172,6 +172,66 @@ describe('SmartSuite – createRecord Operation', () => {
     );
   });
 
+  it('should send an array when value is a JSON array string (LinkedRecord multi-value)', async () => {
+    executeMock = createMockExecuteWithResources({
+      parameters: {
+        'fieldsUi': {
+          fieldsValues: [{ field: 'linked_records', value: '["id1","id2"]' }],
+        },
+      },
+      apiRequestResponse: { id: 'record-id' },
+      inputData: [{ json: {} }],
+    });
+
+    await createRecord.call(executeMock);
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      'POST',
+      '/applications/dummy-table-id/records/',
+      { linked_records: ['id1', 'id2'] },
+    );
+  });
+
+  it('should keep raw string when value is not valid JSON', async () => {
+    executeMock = createMockExecuteWithResources({
+      parameters: {
+        'fieldsUi': {
+          fieldsValues: [{ field: 'title', value: 'plain text' }],
+        },
+      },
+      apiRequestResponse: { id: 'record-id' },
+      inputData: [{ json: {} }],
+    });
+
+    await createRecord.call(executeMock);
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      'POST',
+      '/applications/dummy-table-id/records/',
+      { title: 'plain text' },
+    );
+  });
+
+  it('should pass through a non-string value (already parsed array) unchanged', async () => {
+    executeMock = createMockExecuteWithResources({
+      parameters: {
+        'fieldsUi': {
+          fieldsValues: [{ field: 'linked_records', value: ['id1', 'id2'] }],
+        },
+      },
+      apiRequestResponse: { id: 'record-id' },
+      inputData: [{ json: {} }],
+    });
+
+    await createRecord.call(executeMock);
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      'POST',
+      '/applications/dummy-table-id/records/',
+      { linked_records: ['id1', 'id2'] },
+    );
+  });
+
   it('should call getSolutionId and getTableId once per execution', async () => {
     const { getSolutionId, getTableId } = require('../../../helpers/validation');
 

--- a/src/nodes/SmartSuite/__tests__/actions/record/updateRecord.test.ts
+++ b/src/nodes/SmartSuite/__tests__/actions/record/updateRecord.test.ts
@@ -157,6 +157,44 @@ describe('SmartSuite – updateRecord Operation', () => {
     expect(result).toEqual([{ json: {} }]);
   });
 
+  it('should send an array when value is a JSON array string (LinkedRecord multi-value)', async () => {
+    executeMock = createMockExecuteWithResources({
+      parameters: {
+        recordId: 'record-123',
+        'fieldsUiUpdate.fieldsValues': [{ field: 'linked_records', value: '["id1","id2"]' }],
+      },
+      apiRequestResponse: {},
+      inputData: [{ json: {} }],
+    });
+
+    await updateRecord.call(executeMock);
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      'PATCH',
+      '/applications/dummy-table-id/records/record-123/',
+      { linked_records: ['id1', 'id2'] },
+    );
+  });
+
+  it('should keep raw string when value is not valid JSON', async () => {
+    executeMock = createMockExecuteWithResources({
+      parameters: {
+        recordId: 'record-123',
+        'fieldsUiUpdate.fieldsValues': [{ field: 'title', value: 'plain text' }],
+      },
+      apiRequestResponse: {},
+      inputData: [{ json: {} }],
+    });
+
+    await updateRecord.call(executeMock);
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      'PATCH',
+      '/applications/dummy-table-id/records/record-123/',
+      { title: 'plain text' },
+    );
+  });
+
   it('should throw raw API error if apiRequest fails unexpectedly', async () => {
     (apiRequest as jest.Mock).mockRejectedValueOnce(new Error('API exploded'));
     jest.spyOn(utils, 'isReservedField').mockReturnValue(false);

--- a/src/nodes/SmartSuite/actions/record/createRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/createRecord.operation.ts
@@ -2,7 +2,7 @@
 
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { debugLog, asIdString, isReservedField } from '../../helpers/utils';
+import { debugLog, asIdString, isReservedField, tryParseJson } from '../../helpers/utils';
 import { apiRequest } from '../../transport/smartSuiteApi';
 import { getSolutionId, getTableId } from '../../helpers/validation';
 import { solutionInput, tableInput, fieldsInput } from '../../shared/resourceInputs';
@@ -57,7 +57,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
     }
 
     const payload = fieldsArr.reduce((obj: IDataObject, { field, value }) => {
-      obj[asIdString(field)] = value;
+      obj[asIdString(field)] = typeof value === 'string' ? tryParseJson(value) ?? value : value;
       return obj;
     }, {});
 

--- a/src/nodes/SmartSuite/actions/record/updateRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/updateRecord.operation.ts
@@ -1,7 +1,7 @@
 // src/nodes/SmartSuite/actions/record/updateRecord.operation.ts
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { debugLog, asIdString, isReservedField } from '../../helpers/utils';
+import { debugLog, asIdString, isReservedField, tryParseJson } from '../../helpers/utils';
 import { apiRequest } from '../../transport/smartSuiteApi';
 import { getSolutionId, getTableId } from '../../helpers/validation';
 
@@ -53,7 +53,7 @@ export async function execute(
 
     // Build request payload
     const payload = fieldsArr.reduce((obj: IDataObject, { field, value }) => {
-      obj[asIdString(field)] = value;
+      obj[asIdString(field)] = typeof value === 'string' ? tryParseJson(value) ?? value : value;
       return obj;
     }, {});
 

--- a/src/nodes/SmartSuite/actions/record/upsertRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/upsertRecord.operation.ts
@@ -1,7 +1,7 @@
 // src/nodes/SmartSuite/actions/record/upsertRecord.operation.ts
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { debugLog, asIdString, isReservedField } from '../../helpers/utils';
+import { debugLog, asIdString, isReservedField, tryParseJson } from '../../helpers/utils';
 import { apiRequest } from '../../transport/smartSuiteApi';
 import { getTableId } from '../../helpers/validation';
 
@@ -74,7 +74,7 @@ export async function execute(
 
     // 6) Prepare payload
     const payload = fieldsArr.reduce((obj: IDataObject, { field, value }) => {
-      obj[asIdString(field)] = value;
+      obj[asIdString(field)] = typeof value === 'string' ? tryParseJson(value) ?? value : value;
       return obj;
     }, {} as IDataObject);
 

--- a/src/nodes/SmartSuite/helpers/utils.ts
+++ b/src/nodes/SmartSuite/helpers/utils.ts
@@ -73,3 +73,15 @@ export const RESERVED_FIELDS = [
 export function isReservedField(slug: string): boolean {
   return (RESERVED_FIELDS as readonly string[]).includes(slug);
 }
+
+/**
+ * Attempt to JSON-parse a string. Returns the parsed value on success, null on failure.
+ * Used to normalize field values that may contain JSON arrays (e.g. LinkedRecord multi-value).
+ */
+export function tryParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}

--- a/src/nodes/SmartSuite/shared/resourceInputs.ts
+++ b/src/nodes/SmartSuite/shared/resourceInputs.ts
@@ -91,9 +91,9 @@ export const fieldsInput: INodeProperties = {
         {
           displayName: 'Value',
           name:        'value',
-          type:        'string',
+          type:        'json',
           default:     '',
-          description: 'Value to assign to that field',
+          description: 'Value to assign to that field. Use a JSON array (e.g. ["id1","id2"]) for multi-value fields like LinkedRecord.',
         },
       ],
     },


### PR DESCRIPTION
## Summary

- Changes the field **Value** input type from `string` → `json` so n8n renders a JSON-aware field that accepts arrays, objects, or plain strings
- Adds `tryParseJson()` helper in `helpers/utils.ts` — safely parses a string to JSON, returns `null` on failure
- Normalizes field values in `createRecord`, `updateRecord`, and `upsertRecord`: if a string value parses as valid JSON (e.g. `["id1","id2"]`), the array is sent to the API; malformed or plain strings pass through unchanged
- Adds test cases for JSON array strings, plain strings, and pre-parsed arrays in `createRecord` and `updateRecord` tests

## Test plan

- [x] `npm test` — all 30 record operation tests pass (including 5 new multi-value cases)
- [x] `npm run build` — compiles clean
- [x] `npm run lint` — no lint errors
- [ ] Manual: create/update a record with a LinkedRecord field set to `["id1","id2"]` — API should receive an actual array

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)