### PR TITLE
Fix: sort field dropdown options alphabetically by label

### DIFF
--- a/src/nodes/SmartSuite/methods/listSearch.ts
+++ b/src/nodes/SmartSuite/methods/listSearch.ts
@@ -119,7 +119,9 @@ export const searchTableFields = async function (
       f.slug.toLowerCase().includes(filter.toLowerCase()),
   );
 
-  const results = filtered.map(serializeField);
+  const results = filtered
+    .sort((a, b) => a.label.localeCompare(b.label))
+    .map(serializeField);
   return { results };
 };
 
@@ -178,7 +180,9 @@ export const searchTableFieldsMutable = async function (
     f.slug.toLowerCase().includes(filter.toLowerCase()),
   );
 
-  const results = filtered.map(serializeField);
+  const results = filtered
+    .sort((a, b) => a.label.localeCompare(b.label))
+    .map(serializeField);
   return { results };
 };
 


### PR DESCRIPTION
## Summary

- `searchTableFields` and `searchTableFieldsMutable` in `methods/listSearch.ts` were returning fields in API order (field creation order in SmartSuite), not alphabetical
- Added `.sort((a, b) => a.label.localeCompare(b.label))` before `.map(serializeField)` in both functions
- `solutionSearch` and `tableSearch` already sorted correctly — this brings field lists in line with the same behavior
- `getTableFields` and `getMutableTableFields` in `loadOptions.ts` delegate to these functions and inherit the fix automatically

## Test plan

- [x] `npm test` — 108/108 tests pass
- [x] `npm run build` — compiles clean
- [x] `npm run lint` — exit 0
- [ ] Manual: open Create/Update Record node, select a table with many fields — dropdown should now show fields A→Z by label

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)