### PR TITLE
Fix: transform fullnamefield string to structured object on write (#12)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ import rename from 'gulp-rename';
 // 1) Node icons (corrected path)
 gulp.task('build:icons', () => {
   return gulp
-    .src('src/nodes/SmartSuite/smartsuite.svg')
+    .src('src/nodes/SmartSuite/SmartSuite.svg')
     .pipe(rename('SmartSuite.svg'))
     .pipe(gulp.dest('dist/nodes/SmartSuite'));
 });
@@ -12,7 +12,7 @@ gulp.task('build:icons', () => {
 // 2) Credential icon (corrected path)
 gulp.task('build:credential-icon', () => {
   return gulp
-    .src('src/nodes/SmartSuite/smartsuite.svg')
+    .src('src/nodes/SmartSuite/SmartSuite.svg')
     .pipe(rename('SmartSuiteApi.svg'))
     .pipe(gulp.dest('dist/credentials'));
 });

--- a/src/nodes/SmartSuite/__tests__/actions/record/createRecord.test.ts
+++ b/src/nodes/SmartSuite/__tests__/actions/record/createRecord.test.ts
@@ -8,7 +8,7 @@ import { createMockExecuteWithResources } from '../../../__tests__/helpers/mockR
 // Mock validation helpers
 jest.mock('../../../helpers/validation', () => ({
   getSolutionId: jest.fn().mockResolvedValue('dummy-solution-id'),
-  getTableId: jest.fn().mockResolvedValue('dummy-table-id'),
+  getTableIdWithStructure: jest.fn().mockResolvedValue({ id: 'dummy-table-id', structure: [] }),
 }));
 
 // Mock transport apiRequest
@@ -232,8 +232,8 @@ describe('SmartSuite – createRecord Operation', () => {
     );
   });
 
-  it('should call getSolutionId and getTableId once per execution', async () => {
-    const { getSolutionId, getTableId } = require('../../../helpers/validation');
+  it('should call getSolutionId and getTableIdWithStructure once per execution', async () => {
+    const { getSolutionId, getTableIdWithStructure } = require('../../../helpers/validation');
 
     executeMock = createMockExecuteWithResources({
       apiRequestResponse: { id: 'record-id' },
@@ -248,6 +248,112 @@ describe('SmartSuite – createRecord Operation', () => {
     await createRecord.call(executeMock);
 
     expect(getSolutionId).toHaveBeenCalledTimes(1);
-    expect(getTableId).toHaveBeenCalledTimes(1);
+    expect(getTableIdWithStructure).toHaveBeenCalledTimes(1);
+  });
+
+  describe('fullnamefield transformation', () => {
+    beforeEach(() => {
+      const { getTableIdWithStructure } = require('../../../helpers/validation');
+      (getTableIdWithStructure as jest.Mock).mockResolvedValue({
+        id: 'dummy-table-id',
+        structure: [{ slug: 'contact_name', label: 'Contact Name', field_type: 'fullnamefield' }],
+      });
+    });
+
+    it('should transform a "First Last" string to a fullname object', async () => {
+      executeMock = createMockExecuteWithResources({
+        parameters: { 'fieldsUi': { fieldsValues: [{ field: 'contact_name', value: 'John Doe' }] } },
+        apiRequestResponse: { id: 'record-id' },
+        inputData: [{ json: {} }],
+      });
+
+      await createRecord.call(executeMock);
+
+      expect(apiRequest).toHaveBeenCalledWith(
+        'POST',
+        '/applications/dummy-table-id/records/',
+        {
+          contact_name: {
+            sys_root: 'John Doe',
+            salutation: '',
+            first_name: 'John',
+            middle_name: '',
+            last_name: 'Doe',
+            suffix: '',
+          },
+        },
+      );
+    });
+
+    it('should pass through an already-object fullname value unchanged', async () => {
+      const existingObj = {
+        sys_root: 'John Doe',
+        salutation: '',
+        first_name: 'John',
+        middle_name: '',
+        last_name: 'Doe',
+        suffix: '',
+      };
+      executeMock = createMockExecuteWithResources({
+        parameters: { 'fieldsUi': { fieldsValues: [{ field: 'contact_name', value: JSON.stringify(existingObj) }] } },
+        apiRequestResponse: { id: 'record-id' },
+        inputData: [{ json: {} }],
+      });
+
+      await createRecord.call(executeMock);
+
+      expect(apiRequest).toHaveBeenCalledWith(
+        'POST',
+        '/applications/dummy-table-id/records/',
+        { contact_name: existingObj },
+      );
+    });
+
+    it('should handle three-part names with middle name', async () => {
+      executeMock = createMockExecuteWithResources({
+        parameters: { 'fieldsUi': { fieldsValues: [{ field: 'contact_name', value: 'Mary Jane Watson' }] } },
+        apiRequestResponse: { id: 'record-id' },
+        inputData: [{ json: {} }],
+      });
+
+      await createRecord.call(executeMock);
+
+      expect(apiRequest).toHaveBeenCalledWith(
+        'POST',
+        '/applications/dummy-table-id/records/',
+        {
+          contact_name: {
+            sys_root: 'Mary Jane Watson',
+            salutation: '',
+            first_name: 'Mary',
+            middle_name: 'Jane',
+            last_name: 'Watson',
+            suffix: '',
+          },
+        },
+      );
+    });
+
+    it('should not transform non-fullnamefield string fields', async () => {
+      const { getTableIdWithStructure } = require('../../../helpers/validation');
+      (getTableIdWithStructure as jest.Mock).mockResolvedValue({
+        id: 'dummy-table-id',
+        structure: [{ slug: 'title', label: 'Title', field_type: 'textfield' }],
+      });
+
+      executeMock = createMockExecuteWithResources({
+        parameters: { 'fieldsUi': { fieldsValues: [{ field: 'title', value: 'John Doe' }] } },
+        apiRequestResponse: { id: 'record-id' },
+        inputData: [{ json: {} }],
+      });
+
+      await createRecord.call(executeMock);
+
+      expect(apiRequest).toHaveBeenCalledWith(
+        'POST',
+        '/applications/dummy-table-id/records/',
+        { title: 'John Doe' },
+      );
+    });
   });
 });

--- a/src/nodes/SmartSuite/__tests__/actions/record/updateRecord.test.ts
+++ b/src/nodes/SmartSuite/__tests__/actions/record/updateRecord.test.ts
@@ -9,7 +9,7 @@ import { createMockExecuteWithResources } from '../../../__tests__/helpers/mockR
 
 // Mock the validation helpers
 jest.mock('../../../helpers/validation', () => ({
-  getTableId: jest.fn().mockResolvedValue('dummy-table-id'),
+  getTableIdWithStructure: jest.fn().mockResolvedValue({ id: 'dummy-table-id', structure: [] }),
   getSolutionId: jest.fn().mockResolvedValue('dummy-solution-id'),
 }));
 
@@ -213,7 +213,7 @@ describe('SmartSuite – updateRecord Operation', () => {
 
   it('should resolve solutionId and tableId only once', async () => {
     const getSolutionIdSpy = jest.spyOn(validation, 'getSolutionId');
-    const getTableIdSpy = jest.spyOn(validation, 'getTableId');
+    const getTableIdWithStructureSpy = jest.spyOn(validation, 'getTableIdWithStructure');
     jest.spyOn(utils, 'isReservedField').mockReturnValue(false);
 
     executeMock = createMockExecuteWithResources({
@@ -231,7 +231,97 @@ describe('SmartSuite – updateRecord Operation', () => {
     await updateRecord.call(executeMock);
 
     expect(getSolutionIdSpy).toHaveBeenCalledTimes(1);
-    expect(getTableIdSpy).toHaveBeenCalledTimes(1);
+    expect(getTableIdWithStructureSpy).toHaveBeenCalledTimes(1);
+  });
+
+  describe('fullnamefield transformation', () => {
+    beforeEach(() => {
+      const { getTableIdWithStructure } = require('../../../helpers/validation');
+      (getTableIdWithStructure as jest.Mock).mockResolvedValue({
+        id: 'dummy-table-id',
+        structure: [{ slug: 'contact_name', label: 'Contact Name', field_type: 'fullnamefield' }],
+      });
+    });
+
+    it('should transform a "First Last" string to a fullname object', async () => {
+      executeMock = createMockExecuteWithResources({
+        parameters: {
+          recordId: 'record-123',
+          'fieldsUiUpdate.fieldsValues': [{ field: 'contact_name', value: 'John Doe' }],
+        },
+        apiRequestResponse: {},
+        inputData: [{ json: {} }],
+      });
+
+      await updateRecord.call(executeMock);
+
+      expect(apiRequest).toHaveBeenCalledWith(
+        'PATCH',
+        '/applications/dummy-table-id/records/record-123/',
+        {
+          contact_name: {
+            sys_root: 'John Doe',
+            salutation: '',
+            first_name: 'John',
+            middle_name: '',
+            last_name: 'Doe',
+            suffix: '',
+          },
+        },
+      );
+    });
+
+    it('should pass through an already-object fullname value unchanged', async () => {
+      const existingObj = {
+        sys_root: 'John Doe',
+        salutation: '',
+        first_name: 'John',
+        middle_name: '',
+        last_name: 'Doe',
+        suffix: '',
+      };
+      executeMock = createMockExecuteWithResources({
+        parameters: {
+          recordId: 'record-123',
+          'fieldsUiUpdate.fieldsValues': [{ field: 'contact_name', value: JSON.stringify(existingObj) }],
+        },
+        apiRequestResponse: {},
+        inputData: [{ json: {} }],
+      });
+
+      await updateRecord.call(executeMock);
+
+      expect(apiRequest).toHaveBeenCalledWith(
+        'PATCH',
+        '/applications/dummy-table-id/records/record-123/',
+        { contact_name: existingObj },
+      );
+    });
+
+    it('should not transform non-fullnamefield string fields', async () => {
+      const { getTableIdWithStructure } = require('../../../helpers/validation');
+      (getTableIdWithStructure as jest.Mock).mockResolvedValue({
+        id: 'dummy-table-id',
+        structure: [{ slug: 'title', label: 'Title', field_type: 'textfield' }],
+      });
+
+      executeMock = createMockExecuteWithResources({
+        parameters: {
+          recordId: 'record-123',
+          'fieldsUiUpdate.fieldsValues': [{ field: 'title', value: 'John Doe' }],
+        },
+        apiRequestResponse: {},
+        inputData: [{ json: {} }],
+      });
+
+      await updateRecord.call(executeMock);
+
+      expect(apiRequest).toHaveBeenCalledWith(
+        'PATCH',
+        '/applications/dummy-table-id/records/record-123/',
+        { title: 'John Doe' },
+      );
+    });
   });
 
   it('should include itemIndex in error when recordId is blank in one item', async () => {

--- a/src/nodes/SmartSuite/__tests__/actions/record/upsertRecord.test.ts
+++ b/src/nodes/SmartSuite/__tests__/actions/record/upsertRecord.test.ts
@@ -8,7 +8,7 @@ import * as validation from '../../../helpers/validation';
 import { createMockExecuteWithResources } from '../../../__tests__/helpers/mockResourceInputs';
 
 jest.mock('../../../helpers/validation', () => ({
-  getTableId: jest.fn().mockResolvedValue('dummy-table-id'),
+  getTableIdWithStructure: jest.fn().mockResolvedValue({ id: 'dummy-table-id', structure: [] }),
 }));
 
 jest.mock('../../../transport/smartSuiteApi', () => ({
@@ -126,13 +126,106 @@ describe('SmartSuite – upsertRecord Operation', () => {
     expect(result[0].json).toEqual({ id: 'abc', name: 'Upserted', created_at: 'today' });
   });
 
-  it('should throw if getTableId fails', async () => {
-    (validation.getTableId as jest.Mock).mockRejectedValueOnce(new Error('bad table'));
+  it('should throw if getTableIdWithStructure fails', async () => {
+    (validation.getTableIdWithStructure as jest.Mock).mockRejectedValueOnce(new Error('bad table'));
 
     executeMock = createMockExecuteWithResources({
       parameters: {},
     });
 
     await expect(upsertRecord.call(executeMock)).rejects.toThrow('bad table');
+  });
+
+  describe('fullnamefield transformation', () => {
+    beforeEach(() => {
+      (validation.getTableIdWithStructure as jest.Mock).mockResolvedValue({
+        id: 'dummy-table-id',
+        structure: [{ slug: 'contact_name', label: 'Contact Name', field_type: 'fullnamefield' }],
+      });
+    });
+
+    it('should transform a "First Last" string to a fullname object on create path', async () => {
+      (apiRequest as jest.Mock)
+        .mockResolvedValueOnce({ items: [] })
+        .mockResolvedValueOnce({ id: 'new-record-id' });
+
+      executeMock = createMockExecuteWithResources({
+        parameters: {
+          matchingField: 'email',
+          condition: 'equals',
+          matchValue: 'john@example.com',
+          'fieldsUiUpdate.fieldsValues': [{ field: 'contact_name', value: 'John Doe' }],
+        },
+      });
+
+      await upsertRecord.call(executeMock);
+
+      const createCall = (apiRequest as jest.Mock).mock.calls[1];
+      expect(createCall[0]).toBe('POST');
+      expect(createCall[2]).toEqual({
+        contact_name: {
+          sys_root: 'John Doe',
+          salutation: '',
+          first_name: 'John',
+          middle_name: '',
+          last_name: 'Doe',
+          suffix: '',
+        },
+      });
+    });
+
+    it('should transform a "First Last" string to a fullname object on update path', async () => {
+      (apiRequest as jest.Mock)
+        .mockResolvedValueOnce({ items: [{ id: 'existing-123' }] })
+        .mockResolvedValueOnce({ id: 'existing-123', updated: true });
+
+      executeMock = createMockExecuteWithResources({
+        parameters: {
+          matchingField: 'email',
+          condition: 'equals',
+          matchValue: 'john@example.com',
+          'fieldsUiUpdate.fieldsValues': [{ field: 'contact_name', value: 'John Doe' }],
+        },
+      });
+
+      await upsertRecord.call(executeMock);
+
+      const updateCall = (apiRequest as jest.Mock).mock.calls[1];
+      expect(updateCall[0]).toBe('PATCH');
+      expect(updateCall[2]).toEqual({
+        contact_name: {
+          sys_root: 'John Doe',
+          salutation: '',
+          first_name: 'John',
+          middle_name: '',
+          last_name: 'Doe',
+          suffix: '',
+        },
+      });
+    });
+
+    it('should not transform non-fullnamefield string fields', async () => {
+      (validation.getTableIdWithStructure as jest.Mock).mockResolvedValue({
+        id: 'dummy-table-id',
+        structure: [{ slug: 'title', label: 'Title', field_type: 'textfield' }],
+      });
+      (apiRequest as jest.Mock)
+        .mockResolvedValueOnce({ items: [] })
+        .mockResolvedValueOnce({ id: 'new-record-id' });
+
+      executeMock = createMockExecuteWithResources({
+        parameters: {
+          matchingField: 'email',
+          condition: 'equals',
+          matchValue: 'x@x.com',
+          'fieldsUiUpdate.fieldsValues': [{ field: 'title', value: 'John Doe' }],
+        },
+      });
+
+      await upsertRecord.call(executeMock);
+
+      const createCall = (apiRequest as jest.Mock).mock.calls[1];
+      expect(createCall[2]).toEqual({ title: 'John Doe' });
+    });
   });
 });

--- a/src/nodes/SmartSuite/actions/record/createRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/createRecord.operation.ts
@@ -2,9 +2,9 @@
 
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { debugLog, asIdString, isReservedField, tryParseJson } from '../../helpers/utils';
+import { debugLog, asIdString, isReservedField, tryParseJson, parseFullName } from '../../helpers/utils';
 import { apiRequest } from '../../transport/smartSuiteApi';
-import { getSolutionId, getTableId } from '../../helpers/validation';
+import { getSolutionId, getTableIdWithStructure } from '../../helpers/validation';
 import { solutionInput, tableInput, fieldsInput } from '../../shared/resourceInputs';
 
 export const description = [
@@ -23,8 +23,9 @@ export const description = [
 ] as const;
 
 export async function execute(this: IExecuteFunctions): Promise<INodeExecutionData[]> {
-  const solutionId = await getSolutionId.call(this, 0);
-  const tableId    = await getTableId.call(this, 0);
+  const solutionId                 = await getSolutionId.call(this, 0);
+  const { id: tableId, structure } = await getTableIdWithStructure.call(this, 0);
+  const fieldTypeMap               = new Map(structure.map((f) => [f.slug, f.field_type]));
 
   debugLog('[Record] createRecord.execute called', this.getNode().parameters);
   const items      = this.getInputData();
@@ -57,7 +58,12 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
     }
 
     const payload = fieldsArr.reduce((obj: IDataObject, { field, value }) => {
-      obj[asIdString(field)] = typeof value === 'string' ? tryParseJson(value) ?? value : value;
+      const slug = asIdString(field);
+      let processed: unknown = typeof value === 'string' ? tryParseJson(value) ?? value : value;
+      if (fieldTypeMap.get(slug) === 'fullnamefield' && typeof processed === 'string') {
+        processed = parseFullName(processed);
+      }
+      obj[slug] = processed as IDataObject[string];
       return obj;
     }, {});
 

--- a/src/nodes/SmartSuite/actions/record/updateRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/updateRecord.operation.ts
@@ -1,15 +1,16 @@
 // src/nodes/SmartSuite/actions/record/updateRecord.operation.ts
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { debugLog, asIdString, isReservedField, tryParseJson } from '../../helpers/utils';
+import { debugLog, asIdString, isReservedField, tryParseJson, parseFullName } from '../../helpers/utils';
 import { apiRequest } from '../../transport/smartSuiteApi';
-import { getSolutionId, getTableId } from '../../helpers/validation';
+import { getSolutionId, getTableIdWithStructure } from '../../helpers/validation';
 
 export async function execute(
   this: IExecuteFunctions,
 ): Promise<INodeExecutionData[]> {
-  const solutionId = await getSolutionId.call(this, 0);
-  const tableId    = await getTableId.call(this, 0);
+  const solutionId                 = await getSolutionId.call(this, 0);
+  const { id: tableId, structure } = await getTableIdWithStructure.call(this, 0);
+  const fieldTypeMap               = new Map(structure.map((f) => [f.slug, f.field_type]));
 
   debugLog('[Record] updateRecord.execute called', this.getNode().parameters, 2);
   const items      = this.getInputData();
@@ -53,7 +54,12 @@ export async function execute(
 
     // Build request payload
     const payload = fieldsArr.reduce((obj: IDataObject, { field, value }) => {
-      obj[asIdString(field)] = typeof value === 'string' ? tryParseJson(value) ?? value : value;
+      const slug = asIdString(field);
+      let processed: unknown = typeof value === 'string' ? tryParseJson(value) ?? value : value;
+      if (fieldTypeMap.get(slug) === 'fullnamefield' && typeof processed === 'string') {
+        processed = parseFullName(processed);
+      }
+      obj[slug] = processed as IDataObject[string];
       return obj;
     }, {});
 

--- a/src/nodes/SmartSuite/actions/record/upsertRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/upsertRecord.operation.ts
@@ -1,15 +1,16 @@
 // src/nodes/SmartSuite/actions/record/upsertRecord.operation.ts
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { debugLog, asIdString, isReservedField, tryParseJson } from '../../helpers/utils';
+import { debugLog, asIdString, isReservedField, tryParseJson, parseFullName } from '../../helpers/utils';
 import { apiRequest } from '../../transport/smartSuiteApi';
-import { getTableId } from '../../helpers/validation';
+import { getTableIdWithStructure } from '../../helpers/validation';
 
 export async function execute(
   this: IExecuteFunctions,
 ): Promise<INodeExecutionData[]> {
-  // Get the table ID (application ID)
-  const tableId = await getTableId.call(this, 0);
+  // Get the table ID (application ID) and field structure
+  const { id: tableId, structure } = await getTableIdWithStructure.call(this, 0);
+  const fieldTypeMap               = new Map(structure.map((f) => [f.slug, f.field_type]));
   debugLog('[UpsertRecord] execute', { tableId }, 2);
 
   const items = this.getInputData();
@@ -74,7 +75,12 @@ export async function execute(
 
     // 6) Prepare payload
     const payload = fieldsArr.reduce((obj: IDataObject, { field, value }) => {
-      obj[asIdString(field)] = typeof value === 'string' ? tryParseJson(value) ?? value : value;
+      const slug = asIdString(field);
+      let processed: unknown = typeof value === 'string' ? tryParseJson(value) ?? value : value;
+      if (fieldTypeMap.get(slug) === 'fullnamefield' && typeof processed === 'string') {
+        processed = parseFullName(processed);
+      }
+      obj[slug] = processed as IDataObject[string];
       return obj;
     }, {} as IDataObject);
 

--- a/src/nodes/SmartSuite/helpers/utils.ts
+++ b/src/nodes/SmartSuite/helpers/utils.ts
@@ -85,3 +85,55 @@ export function tryParseJson(value: string): unknown {
     return null;
   }
 }
+
+export interface SmartSuiteFullName {
+  sys_root: string;
+  salutation: string;
+  first_name: string;
+  middle_name: string;
+  last_name: string;
+  suffix: string;
+}
+
+/**
+ * Converts a full name string (e.g. "John Doe") into the SmartSuite
+ * fullnamefield object format. If the input is already an object with
+ * the expected keys, it is normalized and passed through.
+ */
+export function parseFullName(value: unknown): SmartSuiteFullName {
+  if (typeof value === 'object' && value !== null) {
+    const v = value as Record<string, unknown>;
+    return {
+      sys_root:    String(v.sys_root    ?? ''),
+      salutation:  String(v.salutation  ?? ''),
+      first_name:  String(v.first_name  ?? ''),
+      middle_name: String(v.middle_name ?? ''),
+      last_name:   String(v.last_name   ?? ''),
+      suffix:      String(v.suffix      ?? ''),
+    };
+  }
+  const str = String(value ?? '').trim();
+  const parts = str.split(/\s+/).filter(Boolean);
+  let firstName = '';
+  let middleName = '';
+  let lastName = '';
+  if (parts.length === 0) {
+    // no-op — all empty
+  } else if (parts.length === 1) {
+    firstName = parts[0];
+  } else if (parts.length === 2) {
+    [firstName, lastName] = parts;
+  } else {
+    firstName  = parts[0];
+    lastName   = parts[parts.length - 1];
+    middleName = parts.slice(1, -1).join(' ');
+  }
+  return {
+    sys_root:    str,
+    salutation:  '',
+    first_name:  firstName,
+    middle_name: middleName,
+    last_name:   lastName,
+    suffix:      '',
+  };
+}

--- a/src/nodes/SmartSuite/helpers/validation.ts
+++ b/src/nodes/SmartSuite/helpers/validation.ts
@@ -28,16 +28,28 @@ export async function getSolutionId(
   return id;
 }
 
+export interface FieldDefinition {
+  slug: string;
+  label: string;
+  field_type: string;
+}
+
 /**
- * Ensures tableId is present, then verifies it exists.
+ * Ensures tableId is present, verifies it exists, AND returns the table's field
+ * structure (so callers can apply field-type-aware payload transformations).
+ * Zero extra API calls vs. getTableId — the GET was already happening.
  */
-export async function getTableId(
+export async function getTableIdWithStructure(
   this: IExecuteFunctions,
   itemIndex = 0,
-): Promise<string> {
+): Promise<{ id: string; structure: FieldDefinition[] }> {
   const id = requireParam.call(this, 'tableId', 'Table', itemIndex);
+  let structure: FieldDefinition[] = [];
   try {
-    await apiRequest.call(this, 'GET', `/applications/${id}`);
+    const resp = (await apiRequest.call(this, 'GET', `/applications/${id}`)) as {
+      structure?: FieldDefinition[];
+    };
+    structure = resp?.structure ?? [];
   } catch (err: any) {
     if (err.message.includes('404')) {
       throw new NodeOperationError(
@@ -48,5 +60,17 @@ export async function getTableId(
     }
     throw err;
   }
+  return { id, structure };
+}
+
+/**
+ * Ensures tableId is present, then verifies it exists.
+ * Thin backward-compat wrapper over getTableIdWithStructure.
+ */
+export async function getTableId(
+  this: IExecuteFunctions,
+  itemIndex = 0,
+): Promise<string> {
+  const { id } = await getTableIdWithStructure.call(this, itemIndex);
   return id;
 }


### PR DESCRIPTION
## Summary

SmartSuite's API requires `fullnamefield` values to be a structured object (`{ sys_root, first_name, middle_name, last_name, salutation, suffix }`) — not a plain string. The node was passing string values through unchanged for all field types, so `"John Doe"` would arrive at the API as a raw string and the field was silently left empty.

This PR adds field-type-aware payload building to the three write operations (create, update, upsert). When the field type is `fullnamefield`, a plain string like `"John Doe"` is split into `first_name` / `last_name` (and `middle_name` for three-part names) before the API call. If the user already supplies a JSON object, it passes through unchanged. All other field types are unaffected.

Fixes #12

---

## Changes

| File | What changed |
|------|-------------|
| `src/nodes/SmartSuite/helpers/utils.ts` | Added `SmartSuiteFullName` interface and `parseFullName()` — splits a string on spaces into first/middle/last parts |
| `src/nodes/SmartSuite/helpers/validation.ts` | Added `FieldDefinition` type and `getTableIdWithStructure()` — returns both the table ID and the field structure array; kept `getTableId` as a thin wrapper for non-write callers |
| `src/nodes/SmartSuite/actions/record/createRecord.operation.ts` | Switched to `getTableIdWithStructure`, applies `parseFullName` for `fullnamefield` entries |
| `src/nodes/SmartSuite/actions/record/updateRecord.operation.ts` | Same change |
| `src/nodes/SmartSuite/actions/record/upsertRecord.operation.ts` | Same change (covers both create and update branches) |
| `gulpfile.js` | Fixed pre-existing SVG filename casing (`SmartSuite.svg` not `smartsuite.svg`) that broke the Linux build |

**Totals**: 8 files changed, 412 insertions, 29 deletions (2 commits)

---

## How it works

```
user input: "John Doe"
  → getTableIdWithStructure() fetches field structure alongside table ID
  → payload builder checks fieldTypeMap.get(slug) === 'fullnamefield'
  → parseFullName("John Doe") → { sys_root: "John Doe", first_name: "John", last_name: "Doe", ... }
  → SmartSuite API receives proper object → field populates correctly

user input: '{"first_name":"John","last_name":"Doe"}' (JSON string)
  → tryParseJson returns object → typeof processed !== 'string' → passes through unchanged

user input: "hello world" on a textfield
  → fieldTypeMap.get(slug) !== 'fullnamefield' → passes through unchanged
```

---

## Validation

| Check | Result |
|-------|--------|
| `bunx tsc --noEmit` | ✅ Zero errors |
| `bun run lint` (eslint) | ✅ Zero warnings / errors |
| `bun run test` (jest) | ✅ 123 tests passed, 0 failed (19 suites) |
| `bun run build` | ✅ Compiled successfully |

**New test coverage (10 tests across 3 files):**
- `createRecord`: "First Last" → object, JSON pass-through, three-part middle name, non-fullnamefield isolation
- `updateRecord`: same patterns (3 tests)
- `upsertRecord`: fullnamefield on create branch, on update branch, non-fullnamefield isolation

---

## Risk

- **No new API calls** — `getTableIdWithStructure` reuses the existing GET already made by `getTableId`; the response is just no longer discarded
- **Backward compatible** — `getTableId` kept as wrapper; list/get/search/delete operations are untouched
- **Empty structure safe** — if the API returns no field structure, `fieldTypeMap.get(slug)` returns `undefined`, the fullnamefield branch is skipped, and values pass through as before
