### PR TITLE
Fix: include received value in empty Record ID errors (#14)

### DIFF
--- a/src/nodes/SmartSuite/__tests__/actions/record/deleteRecord.test.ts
+++ b/src/nodes/SmartSuite/__tests__/actions/record/deleteRecord.test.ts
@@ -97,6 +97,19 @@ describe('SmartSuite – deleteRecord Operation', () => {
     await expect(deleteRecord.call(executeMock)).rejects.toThrow(
       'Record ID is required for Delete Record operation.',
     );
+    await expect(deleteRecord.call(executeMock)).rejects.toThrow('Received: "   "');
+  });
+
+  it('should include undefined in error message when recordId is undefined', async () => {
+    executeMock = createMockExecuteWithResources({
+      apiRequestResponse: {},
+      inputData: [{ json: {} }],
+    });
+
+    // @ts-ignore
+    executeMock.getNodeParameter = () => undefined;
+
+    await expect(deleteRecord.call(executeMock)).rejects.toThrow('Received: undefined');
   });
 
   it('should throw "Record ID is not valid" when API returns 404 status', async () => {

--- a/src/nodes/SmartSuite/__tests__/actions/record/getRecord.test.ts
+++ b/src/nodes/SmartSuite/__tests__/actions/record/getRecord.test.ts
@@ -92,6 +92,24 @@ describe('SmartSuite – getRecord Operation', () => {
     await expect(getRecord.call(executeMock)).rejects.toThrow(
       'Record ID is required for Get Record operation.'
     );
+    await expect(getRecord.call(executeMock)).rejects.toThrow('Received: "   "');
+  });
+
+  it('should include undefined in error message when recordId is undefined', async () => {
+    executeMock = createMockExecuteWithResources({
+      parameters: {},
+      apiRequestResponse: {},
+      inputData: [{ json: {} }]
+    });
+
+    jest.spyOn(executeMock, 'getNodeParameter').mockImplementation((name: string) => {
+      if (name === 'recordId') return undefined;
+      if (name === 'hydrated') return false;
+      if (name === 'solutionId') return 'dummy-solution-id';
+      return undefined;
+    });
+
+    await expect(getRecord.call(executeMock)).rejects.toThrow('Received: undefined');
   });
 
   it('should return an empty array when there are no input items', async () => {

--- a/src/nodes/SmartSuite/__tests__/actions/record/updateRecord.test.ts
+++ b/src/nodes/SmartSuite/__tests__/actions/record/updateRecord.test.ts
@@ -59,6 +59,7 @@ describe('SmartSuite – updateRecord Operation', () => {
     await expect(updateRecord.call(executeMock)).rejects.toThrow(
       'Record ID is required for Update Record operation.',
     );
+    await expect(updateRecord.call(executeMock)).rejects.toThrow('Received: "  "');
   });
 
   it('should throw error if no fields provided', async () => {
@@ -342,5 +343,21 @@ describe('SmartSuite – updateRecord Operation', () => {
       expect(err).toBeInstanceOf(NodeOperationError);
       expect(err.context?.itemIndex).toBe(1);
     }
+  });
+
+  it('should include undefined in error message when recordId is undefined', async () => {
+    executeMock = createMockExecuteWithResources({
+      parameters: {},
+      inputData: [{ json: {} }],
+    });
+
+    const getNodeParam = jest.spyOn(executeMock, 'getNodeParameter');
+    getNodeParam.mockImplementation((param, index) => {
+      if (param === 'recordId') return undefined;
+      if (param === 'fieldsUiUpdate.fieldsValues') return [{ field: 'f', value: 'v' }];
+      return undefined;
+    });
+
+    await expect(updateRecord.call(executeMock)).rejects.toThrow('Received: undefined');
   });
 });

--- a/src/nodes/SmartSuite/actions/record/deleteRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/deleteRecord.operation.ts
@@ -32,11 +32,12 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
   const returnData: INodeExecutionData[] = [];
 
   for (let i = 0; i < items.length; i++) {
-    const recordId = asIdString(this.getNodeParameter('recordId', i));
+    const rawRecordId = this.getNodeParameter('recordId', i);
+    const recordId = asIdString(rawRecordId);
     if (!recordId.trim()) {
       throw new NodeOperationError(
         this.getNode(),
-        'Record ID is required for Delete Record operation.',
+        `Record ID is required for Delete Record operation. Received: ${JSON.stringify(rawRecordId)}`,
         { itemIndex: i },
       );
     }

--- a/src/nodes/SmartSuite/actions/record/getRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/getRecord.operation.ts
@@ -16,11 +16,12 @@ export async function execute(
   const returnData: INodeExecutionData[] = [];
 
   for (let i = 0; i < items.length; i++) {
-    const recordId = asIdString(this.getNodeParameter('recordId', i));
+    const rawRecordId = this.getNodeParameter('recordId', i);
+    const recordId = asIdString(rawRecordId);
     if (!recordId.trim()) {
       throw new NodeOperationError(
         this.getNode(),
-        'Record ID is required for Get Record operation.',
+        `Record ID is required for Get Record operation. Received: ${JSON.stringify(rawRecordId)}`,
         { itemIndex: i },
       );
     }

--- a/src/nodes/SmartSuite/actions/record/updateRecord.operation.ts
+++ b/src/nodes/SmartSuite/actions/record/updateRecord.operation.ts
@@ -17,11 +17,12 @@ export async function execute(
   const returnData: INodeExecutionData[] = [];
 
   for (let i = 0; i < items.length; i++) {
-    const recordId = asIdString(this.getNodeParameter('recordId', i));
+    const rawRecordId = this.getNodeParameter('recordId', i);
+    const recordId = asIdString(rawRecordId);
     if (!recordId.trim()) {
       throw new NodeOperationError(
         this.getNode(),
-        'Record ID is required for Update Record operation.',
+        `Record ID is required for Update Record operation. Received: ${JSON.stringify(rawRecordId)}`,
         { itemIndex: i },
       );
     }


### PR DESCRIPTION
Closes #14

## Problem
"Record ID is required for ... operation" fires with no information about what value was actually received, making per-item failures (e.g. `[item 1]`) hard to diagnose from the error text alone.

## Root cause (issue #14)
The reporter's Record ID field looked populated because n8n's expression preview only reflects the first/selected item. For a different item (item 1), `$('Merge').item.json.id` resolved to `undefined` at runtime — validation correctly caught this, but said nothing about *what* it received.

## Fix
`getRecord`, `updateRecord`, and `deleteRecord` now append the actual resolved value to the error, e.g.:

`Record ID is required for Update Record operation. Received: undefined`

## Testing
- `npm test` — 126/126 tests pass (19/19 suites)
- `npm run lint` — clean
- `npm run build` — clean
